### PR TITLE
fix: use .env.example in ci

### DIFF
--- a/.github/workflows/build_alpha_release.yml
+++ b/.github/workflows/build_alpha_release.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   build_android:
     runs-on: ubuntu-latest
+    environment: test
     steps:
       - uses: actions/checkout@v4
       - name: Git Sumbodule Update

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -29,8 +29,7 @@ platform :android do
   lane :alpha do
     sh "pnpm install -g @ionic/cli"
     sh "pnpm install"
-    # sh "echo 'PUBLIC_BACKEND_URL=#{ENV["PUBLIC_BACKEND_URL"]}' > .env"
-    sh "cp ../.env.example .env"
+    # sh "cp ../.env.example .env"
     sh "ionic cap sync android"
     sh "ionic cap build android --no-open"
     gradle(

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -29,7 +29,7 @@ platform :android do
   lane :alpha do
     sh "pnpm install -g @ionic/cli"
     sh "pnpm install"
-    # sh "cp ../.env.example .env"
+    sh "cp ../.env.example .env"
     sh "ionic cap sync android"
     sh "ionic cap build android --no-open"
     gradle(

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -29,7 +29,8 @@ platform :android do
   lane :alpha do
     sh "pnpm install -g @ionic/cli"
     sh "pnpm install"
-    sh "cp .env.example .env"
+    # sh "echo 'PUBLIC_BACKEND_URL=#{ENV["PUBLIC_BACKEND_URL"]}' > .env"
+    sh "cp ../.env.example .env"
     sh "ionic cap sync android"
     sh "ionic cap build android --no-open"
     gradle(


### PR DESCRIPTION
- fix: env to be fed to svelte build
- fix: use better solution (github envoiroments variables
- fix: use .env.example in ci
