### PR TITLE
fix: copy correct files on postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 		"apk": "ionic capacitor copy android && cd android && ./gradlew assembleDebug && ./gradlew installDebug && cd ..",
 		"web": "ionic serve",
 		"icons": "npx capacitor-assets generate --ios --android",
-		"postinstall": "paraglide-js compile --project ./project.inlang && cp -r ./node_modules/@didroom/components/dist/ ./static/components"
+		"postinstall": "paraglide-js compile --project ./project.inlang && cp -r ./node_modules/@didroom/components/dist/. ./static/components"
 	},
 	"devDependencies": {
 		"@axe-core/playwright": "^4.10.1",


### PR DESCRIPTION
cp -r has different behaviour on linux and macos as it was written before on linux it would end up copying the dist folder in static/components/ and not just it content, now it should act in the same way on both OS
